### PR TITLE
Fix query range for token history

### DIFF
--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -19,7 +19,8 @@ export default function AdminPanel({ wallet }) {
     // 入力フォームに表示する CID
     const [cid, setCid] = useState('');
     // コントラクトに保存されている URI 一覧
-    const [uris, setUris] = useState([]);
+    // 複数のメタデータ URI を管理する（画面表示には未使用）
+    const [, setUris] = useState([]);
 
     // コントラクトを読み取り専用で取得
     const getReadContract = async () => {

--- a/frontend/src/components/History.jsx
+++ b/frontend/src/components/History.jsx
@@ -63,7 +63,7 @@ export default function History({ wallet, refreshTrigger }) {
                 const latest = await provider.getBlockNumber();
                 const evts = await contract.queryFilter(
                     contract.filters.Transfer(null, wallet),
-                    latest - 10000, // 直近1万ブロックを検索
+                    Math.max(latest - 10000, 0), // 直近1万ブロックを検索。0 より下は指定しない
                     'latest'
                 );
                 tokenIds = evts.map((e) => BigInt(e.args.tokenId).toString());


### PR DESCRIPTION
## Summary
- prevent negative block ranges when querying past token history
- address lint error in AdminPanel

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6854c6916eac833097c23dd890a112e2